### PR TITLE
Remove Blog Reference from Website

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,4 +55,3 @@ analysis.
 
 - [Twitter](https://twitter.com/emissions_api)
 - [Mastodon](https://mastodon.social/@emissions_api)
-- [Blog](https://blog.emissions-api.org/)


### PR DESCRIPTION
We do not have a blog anymore. So we should not refer to it.

Signed-off-by: Sven Haardiek <sven@haardiek.de>