### PR TITLE
Update Design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'github-pages', group: :jekyll_plugins

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; font-src 'self' data:; img-src 'self'; script-src 'self' https://code.jquery.com/jquery-1.12.4.min.js; style-src 'self' 'unsafe-inline' ">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js"
+            integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+            crossorigin="anonymous"></script>
+    <script src="{{ '/assets/js/respond.js' | relative_url }}"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+  </head>
+  <body>
+
+    <div class="wrapper">
+
+      <section>
+        <div id="title">
+          <p><img src="{{ '/assets/img/emissions-api-8.svg' | relative_url }}"
+                  /></p>
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+          <p>{{ site.description | default: site.github.project_tagline }}</p>
+          <hr>
+          <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
+          <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></span>
+          <a class=button href="{{ site.github.owner_url }}">View On GitHub</a>
+        </div>
+
+        {{ content }}
+
+      </section>
+
+    </div>
+  </body>
+</html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,36 @@
+---
+---
+
+@import "jekyll-theme-midnight";
+
+#title {
+	text-align: center;
+}
+
+#title a.button {
+	display: inline-block;
+	padding: 10px 12px;
+	background-color: #93bd20;
+	color: white;
+	border: none;
+	border-radius: 5px;
+}
+
+#title a.button:hover {
+	background-color: #7a1;
+	color: white;
+}
+
+#title img {
+	width: 70px;
+}
+
+.credits {
+	position: absolute;
+	bottom: 3px;
+	float: none !important;
+}
+
+.right {
+	right: 0px;
+}

--- a/assets/img/emissions-api-8.svg
+++ b/assets/img/emissions-api-8.svg
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="800mm"
+   height="800mm"
+   viewBox="0 0 800 800"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="emissions-api-8.svg"
+   inkscape:export-filename="/home/lars/cloud/dropbox/emissions-api/emissions-api-5.svg.png"
+   inkscape:export-xdpi="60.0075"
+   inkscape:export-ydpi="60.0075">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="666.07241"
+     inkscape:cy="1440.458"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="3840"
+     inkscape:window-height="2107"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-right="20"
+     fit-margin-bottom="20" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(806.34134,410.05546)">
+    <rect
+       ry="100"
+       rx="100"
+       y="-410.05548"
+       x="6.3413086"
+       height="800"
+       width="800"
+       id="rect949"
+       style="opacity:1;vector-effect:none;fill:#414141;fill-opacity:1;stroke:none;stroke-width:0.98900002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       transform="scale(-1,1)" />
+    <flowRoot
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot955"
+       xml:space="preserve"
+       transform="matrix(-0.494525,0,0,0.494525,-546.82657,53.448575)"><flowRegion
+         id="flowRegion957"><rect
+           y="1363.6221"
+           x="651.42859"
+           height="48.57143"
+           width="17.142857"
+           id="rect959" /></flowRegion><flowPara
+         id="flowPara961" /></flowRoot>    <g
+       id="g863"
+       transform="translate(-21.638747,20.077318)">
+      <g
+         transform="matrix(-1.2591056,0,0,1.2591056,-1068.3169,-74.739308)"
+         id="g845">
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:0.98900002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -469.23843,72.578921 0.47278,21.30876 h -24.87118 l 0.47278,-21.30876 z m 0.71325,32.150089 2.97259,91.81676 -31.17667,-7.262 2.85196,-84.55476 z"
+           id="rect815"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:0.98900002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -537.27682,67.287254 0.47277,21.30876 h -24.87117 l 0.47277,-21.30876 z m 0.71325,32.150089 2.70809,81.545867 -25.32299,-6.24029 -5.38705,1.78656 2.64982,-77.092137 z"
+           id="rect815-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccc" />
+        <g
+           style="fill:#bcbcbc;fill-opacity:1;stroke:none;stroke-width:1.99989891;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g824-3-7"
+           transform="matrix(-0.494525,0,0,0.494525,-1022.1441,113.22373)">
+          <path
+             style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:7.5586729;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -1688.3223,-1165.3005 -3.6132,162.8575 h 190.0839 l -3.6132,-162.8575 z m -5.4511,245.71495 -22.7774,743.4586 241.0879,79.953122 -24.5508,-823.411722 z"
+             transform="matrix(0.26458333,0,0,0.26458333,-380.30987,204.72846)"
+             id="rect815-6-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccccccc" />
+        </g>
+        <path
+           style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:0.98900002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m -349.2664,244.60585 -209.91218,-59.39561 -110.47145,36.63607 v 66.60481 l 110.47145,-36.63605 209.91218,36.63605 z"
+           id="rect862-3-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;stroke:#000000;stroke-width:0.13084307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -405.0887,77.984263 c 11.67273,0.32662 21.62429,-16.224243 30.70514,-2.195669 9.37175,4.30351 21.64305,3.920104 29.65715,-3.028809 0.80802,-10.472378 5.43715,-22.242622 17.80091,-19.766565 15.85912,-8.231616 12.40922,-35.485939 -4.31933,-40.693975 -7.77822,-6.471121 -5.089,-22.589598 -19.64589,-22.880285 -16.95379,-2.710887 -34.14191,-0.482464 -50.83974,2.9262277 -9.32299,1.369899 -17.39296,-6.0643157 -26.6659,-7.1460587 -14.5117,-3.273771 -31.3714,-0.989461 -42.06913,10.1681254 -9.26295,10.1987666 -25.28513,-2.4257537 -37.75505,-0.7102807 -13.86299,-1.16155 -28.98898,-0.70995 -41.40362,5.85239667 0,0 -14.57205,14.93241863 -22.4206,8.15627443 -17.80772,-2.056562 -28.12661,1.7051372 -41.03827,14.8719342 -0.70264,10.448255 -19.05322,5.531129 -13.86837,18.307138 3.21096,13.532509 16.5889,9.778659 24.43799,3.315682 12.83729,2.349641 29.24923,10.461492 42.34743,8.198635 16.98079,-3.267539 28.07696,-17.208975 43.49079,-6.907474 13.25839,8.860964 33.91452,15.042992 45.8824,5.568551 17.23997,-1.818083 18.79661,7.460283 26.99601,15.181999 11.06169,7.431906 25.23664,12.878212 38.70808,10.782153 z"
+           id="path930"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccsccc" />
+      </g>
+      <g
+         style="fill:#bcbcbc;fill-opacity:1;stroke:none"
+         transform="translate(-83.944347,28.726189)"
+         id="g909">
+        <g
+           style="fill:#bcbcbc;fill-opacity:1;stroke:none"
+           id="g1005"
+           transform="rotate(19.595201,-904.92033,1564.9696)">
+          <g
+             style="fill:#bcbcbc;fill-opacity:1;stroke:none"
+             id="g1018"
+             transform="rotate(7.3079565,-1383.7229,-951.26969)">
+            <rect
+               style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect955"
+               width="89.202377"
+               height="89.202377"
+               x="-837.59528"
+               y="-507.33334" />
+            <rect
+               style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:1.90471971;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect955-1"
+               width="135.84152"
+               height="53.127884"
+               x="-993.20703"
+               y="-489.29611" />
+            <rect
+               style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:1.90471971;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect955-1-2"
+               width="135.84154"
+               height="53.127888"
+               x="-728.62268"
+               y="-489.29611" />
+          </g>
+        </g>
+        <g
+           style="fill:#bcbcbc;fill-opacity:1;stroke:none"
+           id="g897"
+           transform="rotate(-15.66918,-111.93419,-2116.6593)">
+          <path
+             style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -837.08778,-346.92132 c -6.50699,67.28147 57.06413,130.79529 123.65683,123.47347 -0.47862,-4.07895 -0.95725,-8.1579 -1.43587,-12.23685 -60.1587,5.23798 -114.67031,-51.25607 -109.77887,-110.31872 -4.14736,-0.30597 -8.29473,-0.61193 -12.44209,-0.9179 z"
+             id="path824"
+             inkscape:connector-curvature="0" />
+          <path
+             style="opacity:1;vector-effect:none;fill:#d2d2d2;fill-opacity:1;stroke:none;stroke-width:1.50103271;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m -807.93142,-344.76951 c -4.54835,49.71738 41.83036,96.74776 91.10106,92.35068 -0.45498,-3.87719 -0.90996,-7.75439 -1.36494,-11.63158 -42.96018,2.64222 -81.15374,-37.7559 -77.98057,-79.8513 -3.91852,-0.28927 -7.83704,-0.57853 -11.75555,-0.8678 z"
+             id="path824-3-6"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This patch slightly updates the main website design, adding the
Emissions API logo and providing a direct link to the GitHub
organization instead of the website repository.

![Screenshot from 2019-11-01 02-38-18](https://user-images.githubusercontent.com/1008395/67996808-5d565400-fc51-11e9-8e06-fec92193d21c.png)
