### PR TITLE
Mobile CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,9 +34,9 @@
     <footer>
 
       <a href=https://prototypefund.de/en
-      title="A Prototypefund Project">
-      <img src="{{ '/assets/img/PrototypeFund-P-Logo.svg' | relative_url }}"
-           alt="Logo of the Prototypefund"/>
+         title="A Prototypefund Project">
+         <img src="{{ '/assets/img/PrototypeFund-P-Logo.svg' | relative_url }}"
+              alt="Logo of the Prototypefund"/>
       </a>
       <a href=https://okfn.de/en
          title="Open Knowledge Foundation Deutschland e.V.">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -45,3 +45,9 @@ footer img {
   max-height: 100px;
   margin: 25px;
 }
+
+@media (max-width: 730px) {
+  footer a {
+    display: block;
+  }
+}


### PR DESCRIPTION
This patch introduces special CSS rules for smaller devices, ensuring
that if one of the images in the footer break, all images are placed
in vertical order.

---

The idea is to prevent something like this:

![aaaaaaaaaaaaaa](https://user-images.githubusercontent.com/1008395/68537042-fa09a780-035d-11ea-9a8a-9b9f29015093.jpeg)
