### PR TITLE
add floss-weekly link to webpage

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,5 +53,4 @@ analysis.
 Publications
 ------------
 
- - [Floss-Weekly Podcast Episode 555: Emissions API](https://twit.tv/shows/floss-weekly/episodes/555)
-
+ - [FLOSS Weekly podcast episode 555: Emissions API](https://twit.tv/shows/floss-weekly/episodes/555)

--- a/index.md
+++ b/index.md
@@ -49,3 +49,10 @@ the satellite data of the Copernicus program, but who do not want to work with
 huge amounts of scientific data directly. We will provide examples and
 libraries to quickly get you started without being an expert in satellite data
 analysis.
+
+Publishments
+------------
+
+ - [Floss-Weekly Podcast Episode 555: Emissions API](https://twit.tv/shows/floss-weekly/episodes/555)
+
+

--- a/index.md
+++ b/index.md
@@ -50,9 +50,8 @@ huge amounts of scientific data directly. We will provide examples and
 libraries to quickly get you started without being an expert in satellite data
 analysis.
 
-Publishments
+Publications
 ------------
 
  - [Floss-Weekly Podcast Episode 555: Emissions API](https://twit.tv/shows/floss-weekly/episodes/555)
-
 


### PR DESCRIPTION
This patch adds the floss-weekly video link to the webpage.

As headline I choose "Publishments" if anyone suggests another name, go ahead. If we have some other publishments, it could linked here as well.

Closes #15 