### PR TITLE
Fixed Typo in Chart.js Example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -5,7 +5,7 @@ There are various ways of working with the satellite based emissions data we pro
 Here are some of our ideas.
 
 <example
-  name="Plotting a Country's Daily Average CO-Values"
+  name="Plotting a Country's Daily Average CO-Value"
   img="/assets/img/chart.js.png"
   href="examples/chart.js" ></example>
 

--- a/examples/chart.js.md
+++ b/examples/chart.js.md
@@ -1,5 +1,5 @@
-Plotting a Country's Daily Average CO-Values
-============================================
+Plotting a Country's Daily Average CO-Value
+===========================================
 
 In this example, we will be using the
 [Average API](https://demo.emissions-api.org/ui/#/default/emissionsapi.web.get_average)


### PR DESCRIPTION
It's a single “average value” and not multiple “average values”.