### PR TITLE
Switch to api.emissions-api.org

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
 
           {% if page.name == "index.md" %}
           <a class=button
-             href=https://demo.emissions-api.org>
+             href=https://api.emissions-api.org>
              <i class="fas fa-globe-africa"></i>
              API <span>alpha</span></a>
           <a class=button

--- a/examples/chart.js.md
+++ b/examples/chart.js.md
@@ -2,7 +2,7 @@ Plotting a Country's Daily Average CO-Value
 ===========================================
 
 In this example, we will be using the
-[Average API](https://demo.emissions-api.org/ui/#/default/emissionsapi.web.get_average)
+[Average API](https://api.emissions-api.org/ui/#/default/emissionsapi.web.get_average)
 to request data for a given country,
 then we will plot this data using [Chart.js](https://chartjs.org).
 The result should look somewhat like this:
@@ -16,11 +16,11 @@ Average Data
 
 First, let's take a look at the data.
 For this, we [request the average carbon monoxide data of Germany for February 2019
-](https://demo.emissions-api.org/api/v1/average.json?country=DE&begin=2019-02-01&end=2019-03-01)
+](https://api.emissions-api.org/api/v1/average.json?country=DE&begin=2019-02-01&end=2019-03-01)
 using the parameters *begin*, *end* and *country*.
 
 ```
-https://demo.emissions-api.org/api/v1/average.json
+https://api.emissions-api.org/api/v1/average.json
     ?country=DE
     &begin=2019-02-01
     &end=2019-03-01
@@ -66,7 +66,7 @@ The next step is to request this data via JavaScript.
 For this, we first specify the URL we want to request:
 
 ```js
-const API_URL = 'https://demo.emissions-api.org/api/v1/average.json'
+const API_URL = 'https://api.emissions-api.org/api/v1/average.json'
         + '?country=DE&begin=2019-02-01&end=2019-03-01'
 ```
 
@@ -176,7 +176,7 @@ The basic idea now is to:
 The resulting code should look somehwat like this:
 
 ```js
-const api_url = 'https://demo.emissions-api.org/api/v1/average.json'
+const api_url = 'https://api.emissions-api.org/api/v1/average.json'
         + '?country=DE&begin=2019-02-01&end=2019-03-01'
 window.onload = function () {
     fetch(api_url)
@@ -227,7 +227,7 @@ That's it!
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
 <script>
-const api_url = 'https://demo.emissions-api.org/api/v1/average.json'
+const api_url = 'https://api.emissions-api.org/api/v1/average.json'
         + '?country=DE&begin=2019-02-01&end=2019-03-01'
 window.onload = function () {
     fetch(api_url)

--- a/examples/deck.gl.md
+++ b/examples/deck.gl.md
@@ -14,10 +14,10 @@ We are mostly following the [scripting get-started](https://github.com/uber/deck
 ## GeoJSON Data
 
 Let's take a look at the data first.
-We request all measured carbon monoxide values from Germany from – let's say – the fourth and fifth of February using the [geo.json](https://demo.emissions-api.org/ui/#/default/emissionsapi.web.get_data) API endpoint and the URL query parameters *begin*, *end* and *polygon*:
+We request all measured carbon monoxide values from Germany from – let's say – the fourth and fifth of February using the [geo.json](https://api.emissions-api.org/ui/#/default/emissionsapi.web.get_data) API endpoint and the URL query parameters *begin*, *end* and *polygon*:
 
 ```
-https://demo.emissions-api.org/api/v1/geo.json
+https://api.emissions-api.org/api/v1/geo.json
     ?begin=2019-02-04
     &end=2019-02-06
     &polygon=9.921906365609232,54.983104153048025,9.9395797054529,54.596641954153256,…,9.921906365609232,54.983104153048025
@@ -85,7 +85,7 @@ const GERMANY = 'polygon=9.921906365609232,54.983104153048025,' +
     '9.921906365609232,54.983104153048025';
 
 // API URL
-const API_URL = 'https://demo.emissions-api.org/api/v1/geo.json?' +
+const API_URL = 'https://api.emissions-api.org/api/v1/geo.json?' +
     GERMANY + '&begin=2019-02-04&end=2019-02-06';
 ```
 
@@ -242,7 +242,7 @@ const GERMANY = 'polygon=9.921906365609232,54.983104153048025,' +
     '9.921906365609232,54.983104153048025';
 
 // API URL
-const API_URL = 'https://demo.emissions-api.org/api/v1/geo.json?' +
+const API_URL = 'https://api.emissions-api.org/api/v1/geo.json?' +
     GERMANY + '&begin=2019-02-04&end=2019-02-06';
 
 new deck.DeckGL({
@@ -335,7 +335,7 @@ const GERMANY = 'polygon=9.921906365609232,54.983104153048025,' +
     '9.921906365609232,54.983104153048025';
 
 // API URL
-const API_URL = 'https://demo.emissions-api.org/api/v1/geo.json?' +
+const API_URL = 'https://api.emissions-api.org/api/v1/geo.json?' +
     GERMANY + '&begin=2019-02-04&end=2019-02-06';
 
 new deck.DeckGL({


### PR DESCRIPTION
This patch switchs from our old server demo.emissions-api.org to our new one
api.emissions-api.org.