### PR TITLE
Simplify FAQ Code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,6 @@ title: Emissions API
 description: Easy access to satellite-based emission data for everyone
 show_downloads: false
 theme: jekyll-theme-midnight
+markdown: kramdown
+kramdown:
+  parse_block_html: true

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -84,6 +84,16 @@ footer img {
   margin: 65px auto;
 }
 
+details summary {
+  font-size: larger;
+  cursor: pointer;
+}
+
+details {
+  border-left: 1px solid silver;
+  padding-left: 10px;
+}
+
 @media (max-width: 730px) {
   footer a {
     display: block;

--- a/faq.md
+++ b/faq.md
@@ -38,11 +38,11 @@ Right now, Emissions API serves carbon monoxide measurements only.
 Several additional data products are available any may find their way into our API in the future.
 A few examples include:
 
-- Ozone (O³)
-- Nitrogen dioxide (NO²)
-- Sulfur dioxide (SO²)
+- Ozone (O₃)
+- Nitrogen dioxide (NO₂)
+- Sulfur dioxide (SO₂)
 - Formaldehyde (HCHO)
-- Methane (CH⁴)
+- Methane (CH₄)
 </details>
 
 <details>

--- a/faq.md
+++ b/faq.md
@@ -1,111 +1,67 @@
-<h2>FAQ</h2>
+FAQ
+===
 
 <details>
-<summary><h3> > What is Emissions API?</h3></summary>
-  <div style="margin-left: 20px;">
-    Emissions API (application programming interface) is a service like the project slogan (easy access to satellite-based emissions data) suggest. With the <a href="https://api.emissions-api.org/ui/">swaggerUI</a> you can get a feeling for the data and submit test requests.<br>
-  </div>
-<br></details>
+<summary>
+What is Emissions API?
+</summary>
+
+Emissions API is a service providing a REST interface to easily access satellite-based emissions data from the European Space Agency's Sentinel-5P satellite.
+Use the [Swagger UI](https://api.emissions-api.org/ui/) to get an overview of the interface and to submit test requests.
+</details>
+
 
 <details>
-<summary><h3> > What does Emissions API consist of?</h3></summary>
-  <div style="margin-left: 20px;">
-    The Emissions API consists of several projects that are all available on <a href="https://github.com/emissions-api">github</a>:
-    <ul>
-      <li>The <a href="https://github.com/emissions-api/sentinel5dl">sentinel5dl</a> project downloads data from the ESA and stores these .nc files to your hard drive.</li>
-      <li>The <a href="https://github.com/emissions-api/sentinel5algorithms">sentinel5algorithm</a> project pre processes the downloaded .nc files.</li>
-      <li>The <a href="https://github.com/emissions-api/emissions-api">emissions-api</a> project uses the sentinel5dl and sentinel5algorithm and puts the data into a database and serves it via an API.</li>
-    </ul>
-  </div>
-<br></details>
+<summary>
+Is it just the API?
+</summary>
+
+In addition to the API, you will find a few additional useful tools on our [GitHub organization page](https://github.com/emissions-api)
+- [sentinel5dl](https://github.com/emissions-api/sentinel5dl">sentinel5dl) automates downloads from the ESA archives
+- [sentinel5algorithm](https://github.com/emissions-api/sentinel5algorithms) provides several methods for working with and processing the data files
+</details>
 
 <details>
-<summary><h3> > What is the source of the data?</h3></summary>
-  <div style="margin-left: 20px;">
-    The data source is the <a href="https://www.esa.int">European Space Agency (ESA)</a> satellite <a href="https://www.esa.int/Applications/Observing_the_Earth/Copernicus/Sentinel-5P">Sentinel-5P </a>.<br>
-  </div>
-<br></details>
+<summary>
+What is the source of the data?
+</summary>
+
+Data source is the [European Space Agency's](https://www.esa.int) satellite [Sentinel-5P](https://esa.int/Applications/Observing_the_Earth/Copernicus/Sentinel-5P).
+</details>
 
 <details>
-<summary><h3> > What is a product?</h3></summary>
-  <div style="margin-left: 20px;">
-    The satellite Sentinel-5P monitors different gas concentrations and aerosols in the atmosphere. Those different substances are called products.<br>
-  </div>
-<br></details>
+<summary>
+What types of emissions are available?
+</summary>
+
+Right now, Emissions API serves carbon monoxide measurements only.
+Several additional data products are available any may find their way into our API in the future.
+A few examples include:
+
+- Ozone (O³)
+- Nitrogen dioxide (NO²)
+- Sulfur dioxide (SO²)
+- Formaldehyde (HCHO)
+- Methane (CH⁴)
+</details>
 
 <details>
-<summary><h3> > Which products overall available via ESA?</h3></summary>
-  <div style="margin-left: 20px;">
-    We are focused on Sentinel-5 level-2 products:
-    <ul>
-      <li>Ozone (O3)</li>
-      <li>Nitrogen dioxide (NO2)</li>
-      <li>Sulfur dioxide (SO2)</li>
-      <li>Formaldehyde (HCHO)</li>
-      <li>Glyoxal (CHOCHO)</li>
-      <li>Methane (CH4)</li>
-      <li>Carbon monoxide (CO)</li>
-      <li>Cloud effective fraction</li>
-      <li>Aerosol UV apsorption index</li>
-      <li>Surface effective albedo</li>
-      <li>UV spectrally resolved irradiance at surface</li>
-    </ul>
-  </div>
-  But the ESA have <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-5/data-products">more</a>.<br>
-<br></details>
+<summary>
+What is the time period for which data is available?
+</summary>
+
+We currently serve data from January to September 2019.
+We are working to extend this to provide data for the full life-span of Sentinel-5P
+which is planned for 7.5 years after its launch in December 2017.
+</details>
 
 <details>
-<summary><h3> > Which products can be processed via this API?</h3></summary>
-  <div style="margin-left: 20px;">
-    Currently only carbon monoxide (CO).<br>
-  </div>
-<br></details>
-
-<details>
-<summary><h3> > Over which time of period are the data available?</h3></summary>
-  <div style="margin-left: 20px;">
-    The life-time of that satellite is 7.5 years. A successor satellite is planned.<br>
-  </div>
-<br></details>
-
-<details>
-<summary><h3> > Which products over, what time are availabe via Emissions API?</h3></summary>
-  <div style="margin-left: 20px;">
-    We started with one product (CO) and imported from january til september 2019. But we are constantly working on importing more products over a longer period.<br>
-  </div>
-<br></details>
-
-<details>
-<summary><h3> > How can I participate?</h3></summary>
-  <div style="margin-left: 20px;">
-    This is an open source project hosted on github. This means everybody can bring input and help improving the project, by e.g.:
-    <ul>
-      <li>using the API (tag the project) and create awesome use cases by visualizing the data</li>
-      <li>forking the project and working on issues</li>
-      <li>collaborate on the documentation</li>
-      <li>creating issues with new ideas</li>
-    </ul>
-    For more information about how to contribute see <a href="https://github.com/emissions-api/emissions-api/blob/master/CONTRIBUTING.rst">here</a>.<br>
-  </div>
-<br></details>
-
-<details>
-<summary><h3> > How to get in contact with emissions API?</h3></summary>
-  <div style="margin-left: 20px;">
-    Via <a href="mailto:info@emissions-api.org">info@emissions-api.org</a>, <a href="https://twitter.com/emissions_api">twitter</a>, <a href="https://mastodon.social/@emissions_api">mastodon</a> or by leaving a comment e.g. on an issue.<br>
-  </div>
- <br></details>
-
-<details>
-<summary><h3> > Do I need a database on my own?</h3></summary>
-  <div style="margin-left: 20px;">
-    No, because you can use the emissions API database by using the <a href="https://api.emissions-api.org/ui/">project API</a> and use the resulting data for your own purpose.<br>But if you would like to set up your own database server click <a href="https://github.com/emissions-api/emissions-api/blob/master/README.rst">here</a>.<br>
-  </div>
-<br></details>
-
-<details>
-<summary><h3> > What is the database needed for?</h3></summary>
-  <div style="margin-left: 20px;">
-    The database is used to store and serve the pre-processed data for <a href="https://github.com/emissions-api/project-notes/tree/master/user-stories">further usage</a> via the emissons API.<br>
-  </div>
-<br></details>
+<summary>
+How to get in contact?
+</summary>
+Send us a mail to [info@emissions-api.org](mailto:info@emissions-api.org)
+or reach out via
+[Twitter](https://twitter.com/emissions_api),
+[Mastodon](https://mastodon.social/@emissions_api) or
+[GitHub](https://github.com/emissions-api)
+</details>


### PR DESCRIPTION
This patch simplifies the FAQ code by removing as much custom HTML as
possible, using default Markdown and CSS instead.

In addition, this is a review of the FAQ content which I updated when
going through the HTML code.