### PR TITLE
Move Contact and GitHub link to Footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,8 +28,6 @@
               <i class="fas fa-question-circle"></i> FAQ</a></li>
           <li class="menu-item"><a href="https://api.emissions-api.org/ui/">
             <i class="fas fa-globe-africa"></i> API (alpha)</a></li>
-          <li class="menu-item"><a href="https://github.com/emissions-api/emissions-api">
-            <i class="fab fa-github"></i> GitHub</a></li>
         </ul>
       </nav>
     </header>
@@ -73,6 +71,9 @@
 
     <footer>
       <div class=social>
+        <a href=mailto:info@emissions-api.org
+          title=Email
+          class="fas fa-envelope"></a>
         <a href=https://twitter.com/emissions_api
            title=Twitter
            class="fab fa-twitter"></a>


### PR DESCRIPTION
This patch moves the GitHub and Contact to the footer as discussed in the
design meeting.