### PR TITLE
Drop Navigation Icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,8 +17,8 @@
   <body>
 
     <header>
-      <a href=/ title="Emissions API :: Home">
-        <img src="{{ '/assets/img/emissions-api-8.svg' | relative_url }}" height="40px" style="margin:5px 0px -5px 5px"/>
+      <a id=project-home href=/ title="Emissions API :: Home">
+        Emissions API
       </a>
       <nav class="nav-collapse">
         <ul>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -94,6 +94,18 @@ details {
   padding-left: 10px;
 }
 
+a#project-home {
+  color: #000;
+  display: inline-block;
+  padding: 1.02em 2em;
+}
+
+@media (max-width: 640px) {
+	a#project-home {
+	  padding-top: 1.3em;
+  }
+}
+
 @media (max-width: 730px) {
   footer a {
     display: block;


### PR DESCRIPTION
This patch drops the small navigation icon in favor of the project's
name.