### PR TITLE
Fix FAQ Arrows in Webkit

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -89,6 +89,10 @@ details summary {
   cursor: pointer;
 }
 
+details summary::-webkit-details-marker {
+  display:none;
+}
+
 details {
   border-left: 1px solid silver;
   padding-left: 10px;


### PR DESCRIPTION
This patch fixes the weird arrows in from of each FAQ item which appears
in Webkit based browsers (e.g. Chrome) due to the use of the HTML
summary tag.