### PR TITLE
Remove Mastodon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,9 +82,6 @@
         <a href=https://github.com/emissions-api
            title=GitHub
            class="fab fa-github"></a>
-        <a href=https://mastodon.social/@emissions_api
-           title=Mastodon
-           class="fab fa-mastodon"></a>
       </div>
 
       <a href=https://prototypefund.de/en


### PR DESCRIPTION
This patch removes the link to Mastodon since no one really manages that
account.